### PR TITLE
Minor bugfix PriorityQueue

### DIFF
--- a/src/PriorityQueue.js
+++ b/src/PriorityQueue.js
@@ -55,6 +55,7 @@ EasyStar.PriorityQueue = function(criteria,heapType) {
 		} else if (this.length === 1) {
 			var onlyValue = queue[0];
 			queue = [];
+                        this.length = 0;
 			return onlyValue;
 		}
 		var oldRoot = queue[0];


### PR DESCRIPTION
Noticed a tiny bug in PriorityQueue, that the queue is never completely emptied. Probably does not affect the A\* algorithm in any way since the example works.
