### PR TITLE
Fix issue #52: Some conditional directions were not working.

### DIFF
--- a/src/easystar.js
+++ b/src/easystar.js
@@ -498,14 +498,14 @@ EasyStar.js = function() {
      * -1,  1 | 0,  1  | 1,  1
      */
     var calculateDirection = function (diffX, diffY) {
-        if (diffX === 0, diffY === -1) return EasyStar.BOTTOM
-        else if (diffX === 1, diffY === -1) return EasyStar.BOTTOM_LEFT
-        else if (diffX === 1, diffY === 0) return EasyStar.LEFT
-        else if (diffX === 1, diffY === 1) return EasyStar.TOP_LEFT
-        else if (diffX === 0, diffY === 1) return EasyStar.TOP
-        else if (diffX === -1, diffY === 1) return EasyStar.TOP_RIGHT
-        else if (diffX === -1, diffY === 0) return EasyStar.RIGHT
-        else if (diffX === -1, diffY === -1) return EasyStar.BOTTOM_RIGHT
+        if (diffX === 0 && diffY === -1) return EasyStar.TOP
+        else if (diffX === 1 && diffY === -1) return EasyStar.TOP_RIGHT
+        else if (diffX === 1 && diffY === 0) return EasyStar.RIGHT
+        else if (diffX === 1 && diffY === 1) return EasyStar.BOTTOM_RIGHT
+        else if (diffX === 0 && diffY === 1) return EasyStar.BOTTOM
+        else if (diffX === -1 && diffY === 1) return EasyStar.BOTTOM_LEFT
+        else if (diffX === -1 && diffY === 0) return EasyStar.LEFT
+        else if (diffX === -1 && diffY === -1) return EasyStar.TOP_LEFT
         throw new Error('These differences are not valid: ' + diffX + ', ' + diffY)
     };
 

--- a/test/easystartest.js
+++ b/test/easystartest.js
@@ -302,14 +302,19 @@ describe("EasyStar.js", function() {
           [0, 0, 0],
       ];
       easyStar.setGrid(grid);
+      easyStar.enableDiagonals();
       easyStar.setAcceptableTiles([0]);
-      easyStar.setDirectionalCondition(1,1, [EasyStar.RIGHT, EasyStar.TOP_RIGHT]);
-      easyStar.setDirectionalCondition(1,2, [EasyStar.LEFT]);
+      easyStar.setDirectionalCondition(2, 1, [EasyStar.TOP]);
+      easyStar.setDirectionalCondition(1, 2, [EasyStar.TOP_RIGHT]);
+      easyStar.setDirectionalCondition(2, 2, [EasyStar.LEFT]);
+      easyStar.setDirectionalCondition(1, 1, [EasyStar.BOTTOM_RIGHT]);
+      easyStar.setDirectionalCondition(0, 1, [EasyStar.RIGHT]);
+      easyStar.setDirectionalCondition(0, 0, [EasyStar.BOTTOM]);
 
-      easyStar.findPath(0, 0, 2, 0, function (path) {
+      easyStar.findPath(2, 0, 0, 0, function (path) {
           expect(path).not.toBeNull();
-          expect(path[3]).toEqual({ x: 1, y: 2})
           expect(path.length).toEqual(7);
+          expect(path[3]).toEqual({ x: 2, y: 2})
           done();
       });
 


### PR DESCRIPTION
This fixes conditional directions, many of which were not working.

First, the `if` statements in `calculateDirection` all had typos in their conditions.

Second, `calculateDirection` was returning the opposite of what it should have returned.

With those two bugs together, the test case happened to return the right result, but it wasn't working in general.