### PR TITLE
Add findPathSync to find & calculate a path then return the result directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ easystar.setAdditionalPointCost(x, y, cost);
 easystar.setTileCost(tileType, multiplicativeCost);
 ```
 ```javascript
+easystar.findPathSync(startX, startY, endX, endY);
+```
+```javascript
 easystar.enableSync();
 ```
 ```javascript

--- a/bin/easystar-0.4.3.js
+++ b/bin/easystar-0.4.3.js
@@ -150,8 +150,8 @@ var EasyStar =
 	    /**
 	    * Sets the tile cost for a particular tile type.
 	    *
-	    * @param {Number} The tile type to set the cost for.
-	    * @param {Number} The multiplicative cost associated with the given tile.
+	    * @param {Number} tileType The tile type to set the cost for.
+	    * @param {Number} cost The multiplicative cost associated with the given tile.
 	    **/
 	    this.setTileCost = function (tileType, cost) {
 	        costMap[tileType] = cost;
@@ -163,7 +163,7 @@ var EasyStar =
 	    *
 	    * @param {Number} x The x value of the point to cost.
 	    * @param {Number} y The y value of the point to cost.
-	    * @param {Number} The multiplicative cost associated with the given point.
+	    * @param {Number} cost The multiplicative cost associated with the given point.
 	    **/
 	    this.setAdditionalPointCost = function (x, y, cost) {
 	        if (pointsToCost[y] === undefined) {
@@ -273,6 +273,29 @@ var EasyStar =
 	    };
 
 	    /**
+	     * Find a path and calculate synchronously
+	     *
+	     * @param {Number} startX
+	     * @param {Number} startY
+	     * @param {Number} endX
+	     * @param {Number} endY
+	     * @returns {Array<{ x: Number, y: Number}|null>}
+	     */
+	    this.findPathSync = function (startX, startY, endX, endY) {
+	        var result = null;
+
+	        syncEnabled = true;
+
+	        this.findPath(startX, startY, endX, endY, function (path) {
+	            result = path;
+	        });
+
+	        this.calculate();
+
+	        return result;
+	    };
+
+	    /**
 	    * Find a path.
 	    *
 	    * @param {Number} startX The X position of the starting point.
@@ -285,17 +308,6 @@ var EasyStar =
 	    *
 	    **/
 	    this.findPath = function (startX, startY, endX, endY, callback) {
-	        // Wraps the callback for sync vs async logic
-	        var callbackWrapper = function (result) {
-	            if (syncEnabled) {
-	                callback(result);
-	            } else {
-	                setTimeout(function () {
-	                    callback(result);
-	                });
-	            }
-	        };
-
 	        // No acceptable tiles were set
 	        if (acceptableTiles === undefined) {
 	            throw new Error("You can't set a path without first calling setAcceptableTiles() on EasyStar.");
@@ -312,7 +324,7 @@ var EasyStar =
 
 	        // Start and end are the same tile.
 	        if (startX === endX && startY === endY) {
-	            callbackWrapper([]);
+	            callback([]);
 	            return;
 	        }
 
@@ -327,7 +339,7 @@ var EasyStar =
 	        }
 
 	        if (isAcceptable === false) {
-	            callbackWrapper(null);
+	            callback(null);
 	            return;
 	        }
 
@@ -342,7 +354,7 @@ var EasyStar =
 	        instance.startY = startY;
 	        instance.endX = endX;
 	        instance.endY = endY;
-	        instance.callback = callbackWrapper;
+	        instance.callback = callback;
 
 	        instance.openList.push(coordinateToNode(instance, instance.startX, instance.startY, null, STRAIGHT_COST));
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -122,6 +122,19 @@ export class js {
    */
   stopAvoidingAllAdditionalPoints(): void
 
+    /**
+     * Find a path synchronously.
+     *
+     * @param {Number} startX The X position of the starting point.
+     * @param {Number} startY The Y position of the starting point.
+     * @param {Number} endX The X position of the ending point.
+     * @param {Number} endY The Y position of the ending point.
+     * is found, or no path is found.
+     * @return {Array<{ x: Number, y: Number }>|null} The result of easystar.calculate(), a path array or null
+     *
+     */
+    findPathSync(startX: number, startY: number, endX: number, endY: number): Array<{ x: number, y: number }>|null
+
   /**
    * Find a path.
    *

--- a/src/easystar.js
+++ b/src/easystar.js
@@ -226,6 +226,29 @@ EasyStar.js = function() {
     };
 
     /**
+     * Find a path and calculate synchronously
+     *
+     * @param {Number} startX
+     * @param {Number} startY
+     * @param {Number} endX
+     * @param {Number} endY
+     * @returns {Array<{ x: Number, y: Number}|null>}
+     */
+    this.findPathSync = function(startX, startY, endX, endY) {
+        var result = null;
+
+        syncEnabled = true;
+
+        this.findPath(startX, startY, endX, endY, function (path) {
+            result = path;
+        });
+
+        this.calculate();
+
+        return result;
+    };
+
+    /**
     * Find a path.
     *
     * @param {Number} startX The X position of the starting point.

--- a/src/easystar.js
+++ b/src/easystar.js
@@ -6,7 +6,7 @@
 *   Implementation By Bryce Neal (@prettymuchbryce)
 **/
 
-var EasyStar = {}
+var EasyStar = {};
 var Instance = require('./instance');
 var Node = require('./node');
 var Heap = require('heap');
@@ -72,14 +72,14 @@ EasyStar.js = function() {
      */
     this.enableDiagonals = function() {
         diagonalsEnabled = true;
-    }
+    };
 
     /**
      * Disable diagonal pathfinding.
      */
     this.disableDiagonals = function() {
         diagonalsEnabled = false;
-    }
+    };
 
     /**
     * Sets the collision grid that EasyStar uses.
@@ -103,8 +103,8 @@ EasyStar.js = function() {
     /**
     * Sets the tile cost for a particular tile type.
     *
-    * @param {Number} The tile type to set the cost for.
-    * @param {Number} The multiplicative cost associated with the given tile.
+    * @param {Number} tileType The tile type to set the cost for.
+    * @param {Number} cost The multiplicative cost associated with the given tile.
     **/
     this.setTileCost = function(tileType, cost) {
         costMap[tileType] = cost;
@@ -116,7 +116,7 @@ EasyStar.js = function() {
     *
     * @param {Number} x The x value of the point to cost.
     * @param {Number} y The y value of the point to cost.
-    * @param {Number} The multiplicative cost associated with the given point.
+    * @param {Number} cost The multiplicative cost associated with the given point.
     **/
     this.setAdditionalPointCost = function(x, y, cost) {
         if (pointsToCost[y] === undefined) {
@@ -135,14 +135,14 @@ EasyStar.js = function() {
         if (pointsToCost[y] !== undefined) {
             delete pointsToCost[y][x];
         }
-    }
+    };
 
     /**
     * Remove all additional point costs.
     **/
     this.removeAllAdditionalPointCosts = function() {
         pointsToCost = {};
-    }
+    };
 
     /**
     * Sets a directional condition on a tile
@@ -238,17 +238,6 @@ EasyStar.js = function() {
     *
     **/
     this.findPath = function(startX, startY, endX, endY, callback) {
-        // Wraps the callback for sync vs async logic
-        var callbackWrapper = function(result) {
-            if (syncEnabled) {
-                callback(result);
-            } else {
-                setTimeout(function() {
-                    callback(result);
-                });
-            }
-        }
-
         // No acceptable tiles were set
         if (acceptableTiles === undefined) {
             throw new Error("You can't set a path without first calling setAcceptableTiles() on EasyStar.");
@@ -267,7 +256,7 @@ EasyStar.js = function() {
 
         // Start and end are the same tile.
         if (startX===endX && startY===endY) {
-            callbackWrapper([]);
+            callback([]);
             return;
         }
 
@@ -282,7 +271,7 @@ EasyStar.js = function() {
         }
 
         if (isAcceptable === false) {
-            callbackWrapper(null);
+            callback(null);
             return;
         }
 
@@ -297,7 +286,7 @@ EasyStar.js = function() {
         instance.startY = startY;
         instance.endX = endX;
         instance.endY = endY;
-        instance.callback = callbackWrapper;
+        instance.callback = callback;
 
         instance.openList.push(coordinateToNode(instance, instance.startX,
             instance.startY, null, STRAIGHT_COST));
@@ -469,13 +458,13 @@ EasyStar.js = function() {
     var isTileWalkable = function(collisionGrid, acceptableTiles, x, y, sourceNode) {
         var directionalCondition = directionalConditions[y] && directionalConditions[y][x];
         if (directionalCondition) {
-            var direction = calculateDirection(sourceNode.x - x, sourceNode.y - y)
+            var direction = calculateDirection(sourceNode.x - x, sourceNode.y - y);
             var directionIncluded = function () {
                 for (var i = 0; i < directionalCondition.length; i++) {
                     if (directionalCondition[i] === direction) return true
                 }
                 return false
-            }
+            };
             if (!directionIncluded()) return false
         }
         for (var i = 0; i < acceptableTiles.length; i++) {
@@ -493,14 +482,14 @@ EasyStar.js = function() {
      * -1,  1 | 0,  1  | 1,  1
      */
     var calculateDirection = function (diffX, diffY) {
-        if (diffX === 0 && diffY === -1) return EasyStar.TOP
-        else if (diffX === 1 && diffY === -1) return EasyStar.TOP_RIGHT
-        else if (diffX === 1 && diffY === 0) return EasyStar.RIGHT
-        else if (diffX === 1 && diffY === 1) return EasyStar.BOTTOM_RIGHT
-        else if (diffX === 0 && diffY === 1) return EasyStar.BOTTOM
-        else if (diffX === -1 && diffY === 1) return EasyStar.BOTTOM_LEFT
-        else if (diffX === -1 && diffY === 0) return EasyStar.LEFT
-        else if (diffX === -1 && diffY === -1) return EasyStar.TOP_LEFT
+        if (diffX === 0 && diffY === -1) return EasyStar.TOP;
+        else if (diffX === 1 && diffY === -1) return EasyStar.TOP_RIGHT;
+        else if (diffX === 1 && diffY === 0) return EasyStar.RIGHT;
+        else if (diffX === 1 && diffY === 1) return EasyStar.BOTTOM_RIGHT;
+        else if (diffX === 0 && diffY === 1) return EasyStar.BOTTOM;
+        else if (diffX === -1 && diffY === 1) return EasyStar.BOTTOM_LEFT;
+        else if (diffX === -1 && diffY === 0) return EasyStar.LEFT;
+        else if (diffX === -1 && diffY === -1) return EasyStar.TOP_LEFT;
         throw new Error('These differences are not valid: ' + diffX + ', ' + diffY)
     };
 
@@ -544,13 +533,13 @@ EasyStar.js = function() {
             return (dx + dy);
         }
     };
-}
+};
 
-EasyStar.TOP = 'TOP'
-EasyStar.TOP_RIGHT = 'TOP_RIGHT'
-EasyStar.RIGHT = 'RIGHT'
-EasyStar.BOTTOM_RIGHT = 'BOTTOM_RIGHT'
-EasyStar.BOTTOM = 'BOTTOM'
-EasyStar.BOTTOM_LEFT = 'BOTTOM_LEFT'
-EasyStar.LEFT = 'LEFT'
-EasyStar.TOP_LEFT = 'TOP_LEFT'
+EasyStar.TOP = 'TOP';
+EasyStar.TOP_RIGHT = 'TOP_RIGHT';
+EasyStar.RIGHT = 'RIGHT';
+EasyStar.BOTTOM_RIGHT = 'BOTTOM_RIGHT';
+EasyStar.BOTTOM = 'BOTTOM';
+EasyStar.BOTTOM_LEFT = 'BOTTOM_LEFT';
+EasyStar.LEFT = 'LEFT';
+EasyStar.TOP_LEFT = 'TOP_LEFT';

--- a/test/easystartest.js
+++ b/test/easystartest.js
@@ -374,43 +374,42 @@ describe('EasyStar.js', function () {
             expect(result[1]).toEqual({x: 0, y: 1});
             expect(result[2]).toEqual({x: 1, y: 1});
         });
-    });
 
-    describe('Asynchrounous', function () {
-        beforeEach(function () {
-            jasmine.clock().install();
-        });
-
-        afterEach(function () {
-            jasmine.clock().uninstall();
-        });
-
-        it('It should defer the findPath callback to the next stack when sync mode is not enabled', function () {
+        it('It should return the path directly from the findPathSync method', function () {
             var easyStar = new EasyStar.js();
-            var result = [];
+            var result;
             var grid = [
                 [0, 1, 0],
                 [0, 0, 0],
                 [0, 0, 0],
             ];
-
             easyStar.setGrid(grid);
             easyStar.setAcceptableTiles([0]);
 
-            easyStar.findPath(0, 0, 1, 1, function (path) {
-                result.push.apply(result, path);
+            result = easyStar.findPathSync(0, 0, 1, 1);
 
-                expect(path.length).toEqual(3);
-                expect(path[0]).toEqual({x: 0, y: 0});
-                expect(path[1]).toEqual({x: 0, y: 1});
-                expect(path[2]).toEqual({x: 1, y: 1});
-            });
+            // Expect our result to be updated immediately
+            // after calculate is invoked
+            expect(result.length).toEqual(3);
+            expect(result[0]).toEqual({x: 0, y: 0});
+            expect(result[1]).toEqual({x: 0, y: 1});
+            expect(result[2]).toEqual({x: 1, y: 1});
+        });
 
-            easyStar.calculate();
+        it('It should return null directly from the findPathSync method if the path cannot be found', function () {
+            var easyStar = new EasyStar.js();
+            var result;
+            var grid = [
+                [0, 1, 0],
+                [1, 1, 0],
+                [0, 0, 0],
+            ];
+            easyStar.setGrid(grid);
+            easyStar.setAcceptableTiles([0]);
 
-            // Expect our result to be deferred until
-            // it is ready
-            expect(result.length).toEqual(0);
+            result = easyStar.findPathSync(0, 0, 2, 2);
+
+            expect(result).toBeNull();
         });
     });
 });

--- a/test/easystartest.js
+++ b/test/easystartest.js
@@ -1,349 +1,416 @@
-describe("EasyStar.js", function() {
+describe('EasyStar.js', function () {
 
-  beforeEach(function() { });
+    beforeEach(function () { });
 
-  it("It should find a path successfully with corner cutting enabled.", function(done) {
-    var easyStar = new EasyStar.js();
-    easyStar.enableDiagonals();
-    var map = [[1,0,0,0,0],
-               [0,1,0,0,0],
-               [0,0,1,0,0],
-               [0,0,0,1,0],
-               [0,0,0,0,1]];
+    it('It should find a path successfully with corner cutting enabled.', function (done) {
+        var easyStar = new EasyStar.js();
+        easyStar.enableDiagonals();
+        var map = [[1, 0, 0, 0, 0],
+            [0, 1, 0, 0, 0],
+            [0, 0, 1, 0, 0],
+            [0, 0, 0, 1, 0],
+            [0, 0, 0, 0, 1]];
 
-    easyStar.setGrid(map);
+        easyStar.setGrid(map);
 
-    easyStar.enableCornerCutting();
+        easyStar.enableCornerCutting();
 
-    easyStar.setAcceptableTiles([1]);
+        easyStar.setAcceptableTiles([1]);
 
-    easyStar.findPath(0,0,4,4,onPathFound);
+        easyStar.findPath(0, 0, 4, 4, onPathFound);
 
-    easyStar.calculate();
+        easyStar.calculate();
 
-    function onPathFound(path) {
-        expect(path).not.toBeNull();
-        expect(path.length).toEqual(5);
-        expect(path[0].x).toEqual(0);
-        expect(path[0].y).toEqual(0);
-        expect(path[3].x).toEqual(3);
-        expect(path[3].y).toEqual(3);
-        done()
-    }
-  });
-
-  it("It should fail to find a path successfully with corner cutting disabled.", function(done) {
-    var easyStar = new EasyStar.js();
-    easyStar.enableDiagonals();
-    var map = [[1,0,0,0,0],
-               [0,1,0,0,0],
-               [0,0,1,0,0],
-               [0,0,0,1,0],
-               [0,0,0,0,1]];
-
-    easyStar.setGrid(map);
-
-    easyStar.disableCornerCutting();
-
-    easyStar.setAcceptableTiles([1]);
-
-    easyStar.findPath(0,0,4,4,onPathFound);
-
-    easyStar.calculate();
-
-    function onPathFound(path) {
-        expect(path).toBeNull();
-        done();
-    }
-  });
-
-  it("It should find a path successfully.", function(done) {
-    var easyStar = new EasyStar.js();
-    var map = [[1,1,0,1,1],
-               [1,1,0,1,1],
-               [1,1,0,1,1],
-               [1,1,1,1,1],
-               [1,1,1,1,1]];
-
-    easyStar.setGrid(map);
-
-    easyStar.setAcceptableTiles([1]);
-
-    easyStar.findPath(1,2,3,2,onPathFound);
-
-    easyStar.calculate();
-
-    function onPathFound(path) {
-        expect(path).not.toBeNull();
-        expect(path.length).toEqual(5);
-        expect(path[0].x).toEqual(1);
-        expect(path[0].y).toEqual(2);
-        expect(path[2].x).toEqual(2);
-        expect(path[2].y).toEqual(3);
-        done();
-    }
-  });
-
-  it("It should be able to cancel a path.", function(done) {
-    var easyStar = new EasyStar.js();
-    var map = [[1,1,0,1,1],
-               [1,1,0,1,1],
-               [1,1,0,1,1],
-               [1,1,1,1,1],
-               [1,1,1,1,1]];
-
-    easyStar.setGrid(map);
-
-    easyStar.setAcceptableTiles([1]);
-
-    var id = easyStar.findPath(1,2,3,2,onPathFound);
-
-    easyStar.cancelPath(id);
-
-    easyStar.calculate();
-
-    function onPathFound(path) {
-        fail("path wasn't cancelled");
-    }
-
-    setTimeout(done, 0);
-  });
-
-  it("Paths should have different IDs.", function() {
-    var easyStar = new EasyStar.js();
-    var map = [[1,1,0,1,1],
-               [1,1,0,1,1],
-               [1,1,0,1,1],
-               [1,1,1,1,1],
-               [1,1,1,1,1]];
-
-    easyStar.setGrid(map);
-
-    easyStar.setAcceptableTiles([1]);
-
-    var id1 = easyStar.findPath(1,2,3,2,onPathFound);
-    var id2 = easyStar.findPath(3,2,1,2,onPathFound);
-    expect(id1).toBeGreaterThan(0);
-    expect(id2).toBeGreaterThan(0);
-    expect(id1).not.toEqual(id2);
-
-    function onPathFound(path) {
-    }
-  });
-
-  it("It should be able to avoid a separate point successfully.", function(done) {
-    var easyStar = new EasyStar.js();
-    var map = [[1,1,0,1,1],
-               [1,1,0,1,1],
-               [1,1,0,1,1],
-               [1,1,1,1,1],
-               [1,1,1,1,1]];
-
-    easyStar.setGrid(map);
-
-    easyStar.avoidAdditionalPoint(2,3);
-
-    easyStar.setAcceptableTiles([1]);
-
-    easyStar.findPath(1,2,3,2,onPathFound);
-
-    easyStar.calculate();
-
-    function onPathFound(path) {
-        expect(path).not.toBeNull();
-        expect(path.length).toEqual(7);
-        expect(path[0].x).toEqual(1);
-        expect(path[0].y).toEqual(2);
-        expect(path[2].x).toEqual(1);
-        expect(path[2].y).toEqual(4);
-        done();
-    }
-  });
-
-  it("It should work with diagonals", function(done) {
-    var easyStar = new EasyStar.js();
-    easyStar.enableDiagonals();
-    var map = [[1,1,1,1,1],
-               [1,1,1,1,1],
-               [1,1,1,1,1],
-               [1,1,1,1,1],
-               [1,1,1,1,1]];
-
-    easyStar.setGrid(map);
-
-    easyStar.setAcceptableTiles([1]);
-
-    easyStar.findPath(0,0,4,4,onPathFound);
-
-    easyStar.calculate();
-
-    function onPathFound(path) {
-        expect(path).not.toBeNull();
-        expect(path.length).toEqual(5);
-        expect(path[0].x).toEqual(0);
-        expect(path[0].y).toEqual(0);
-        expect(path[1].x).toEqual(1);
-        expect(path[1].y).toEqual(1);
-        expect(path[2].x).toEqual(2);
-        expect(path[2].y).toEqual(2);
-        expect(path[3].x).toEqual(3);
-        expect(path[3].y).toEqual(3);
-        expect(path[4].x).toEqual(4);
-        expect(path[4].y).toEqual(4);
-        done();
-    }
-  });
-
-  it("It should move in a straight line with diagonals", function(done) {
-    var easyStar = new EasyStar.js();
-    easyStar.enableDiagonals();
-    var map = [[1,1,1,1,1,1,1,1,1,1],
-               [1,1,0,1,1,1,1,0,1,1],
-               [1,1,1,1,1,1,1,1,1,1],
-               [1,1,1,1,1,1,1,1,1,1],
-               [1,1,1,1,1,1,1,1,1,1],
-               [1,1,1,1,1,1,1,1,1,1],
-               [1,1,1,1,1,1,1,1,1,1],
-               [1,1,1,1,1,1,1,1,1,1],
-               [1,1,1,1,1,1,1,1,1,1],
-               [1,1,1,1,1,1,1,1,1,1]];
-
-    easyStar.setGrid(map);
-
-    easyStar.enableDiagonals();
-
-    easyStar.setAcceptableTiles([1]);
-
-    easyStar.findPath(0,0,9,0,onPathFound);
-
-    easyStar.calculate();
-
-    function onPathFound(path) {
-        expect(path).not.toBeNull();
-        for (var i = 0; i < path.length; i++) {
-            expect(path[i].y).toEqual(0);
+        function onPathFound (path) {
+            expect(path).not.toBeNull();
+            expect(path.length).toEqual(5);
+            expect(path[0].x).toEqual(0);
+            expect(path[0].y).toEqual(0);
+            expect(path[3].x).toEqual(3);
+            expect(path[3].y).toEqual(3);
+            done();
         }
-        done();
-    }
-  });
-
-  it("It should return empty path when start and end are the same tile.", function(done) {
-    var easyStar = new EasyStar.js();
-    var map = [[1,1,0,1,1],
-               [1,1,0,1,1],
-               [1,1,0,1,1],
-               [1,1,1,1,1],
-               [1,1,1,1,1]];
-
-    easyStar.setGrid(map);
-
-    easyStar.setAcceptableTiles([1]);
-
-    easyStar.findPath(1,2,1,2,onPathFound);
-
-    easyStar.calculate();
-
-    function onPathFound(path) {
-        expect(path).not.toBeNull();
-        expect(path.length).toEqual(0);
-        done();
-    }
-  });
-
-  it("It should prefer straight paths when possible", function(done) {
-    var easyStar = new EasyStar.js();
-    easyStar.setAcceptableTiles([0]);
-    easyStar.enableDiagonals();
-    easyStar.setGrid([
-        [0, 0, 0],
-        [0, 0, 0],
-        [0, 0, 0]
-    ]);
-
-    easyStar.findPath(0, 1, 2, 1, function(path){
-        expect(path).not.toBeNull();
-        expect(path[1].x).toEqual(1);
-        expect(path[1].y).toEqual(1);
-        done();
     });
 
-    easyStar.calculate();
-  });
+    it('It should fail to find a path successfully with corner cutting disabled.', function (done) {
+        var easyStar = new EasyStar.js();
+        easyStar.enableDiagonals();
+        var map = [[1, 0, 0, 0, 0],
+            [0, 1, 0, 0, 0],
+            [0, 0, 1, 0, 0],
+            [0, 0, 0, 1, 0],
+            [0, 0, 0, 0, 1]];
 
-  it("It should prefer diagonal paths when they are faster", function(done) {
-    var easyStar = new EasyStar.js();
-    var grid = [];
-    for (var i = 0; i < 20; i++) {
-        grid[i] = [];
-        for (var j = 0; j < 20; j++) {
-          grid[i][j] = 0;
+        easyStar.setGrid(map);
+
+        easyStar.disableCornerCutting();
+
+        easyStar.setAcceptableTiles([1]);
+
+        easyStar.findPath(0, 0, 4, 4, onPathFound);
+
+        easyStar.calculate();
+
+        function onPathFound (path) {
+            expect(path).toBeNull();
+            done();
         }
-    }
-    easyStar.setGrid(grid);
-    easyStar.setAcceptableTiles([0]);
-    easyStar.enableDiagonals();
-
-    easyStar.findPath(4, 4, 2, 2, function(path){
-        expect(path).not.toBeNull();
-        expect(path.length).toEqual(3);
-        expect(path[1].x).toEqual(3);
-        expect(path[1].y).toEqual(3);
-        done();
     });
 
-    easyStar.calculate();
-  })
+    it('It should find a path successfully.', function (done) {
+        var easyStar = new EasyStar.js();
+        var map = [[1, 1, 0, 1, 1],
+            [1, 1, 0, 1, 1],
+            [1, 1, 0, 1, 1],
+            [1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1]];
 
-  it("It should handle tiles with a directional condition", function (done) {
-      var easyStar = new EasyStar.js();
-      var grid = [
-          [0, 1, 0],
-          [0, 0, 0],
-          [0, 0, 0],
-      ];
-      easyStar.setGrid(grid);
-      easyStar.enableDiagonals();
-      easyStar.setAcceptableTiles([0]);
-      easyStar.setDirectionalCondition(2, 1, [EasyStar.TOP]);
-      easyStar.setDirectionalCondition(1, 2, [EasyStar.TOP_RIGHT]);
-      easyStar.setDirectionalCondition(2, 2, [EasyStar.LEFT]);
-      easyStar.setDirectionalCondition(1, 1, [EasyStar.BOTTOM_RIGHT]);
-      easyStar.setDirectionalCondition(0, 1, [EasyStar.RIGHT]);
-      easyStar.setDirectionalCondition(0, 0, [EasyStar.BOTTOM]);
+        easyStar.setGrid(map);
 
-      easyStar.findPath(2, 0, 0, 0, function (path) {
-          expect(path).not.toBeNull();
-          expect(path.length).toEqual(7);
-          expect(path[3]).toEqual({ x: 2, y: 2})
-          done();
-      });
+        easyStar.setAcceptableTiles([1]);
 
-      easyStar.calculate();
-  })
+        easyStar.findPath(1, 2, 3, 2, onPathFound);
 
-  it("It should handle tiles with a directional condition and no corner cutting", function (done) {
-      var easyStar = new EasyStar.js();
-      easyStar.disableCornerCutting();
-      var grid = [
-          [0, 1, 0],
-          [0, 0, 0],
-          [0, 0, 0],
-      ];
-      easyStar.setGrid(grid);
-      easyStar.enableDiagonals();
-      easyStar.setAcceptableTiles([0]);
-      easyStar.setDirectionalCondition(2, 1, [EasyStar.TOP]);
-      easyStar.setDirectionalCondition(1, 1, [EasyStar.RIGHT]);
-      easyStar.setDirectionalCondition(0, 1, [EasyStar.RIGHT]);
-      easyStar.setDirectionalCondition(0, 0, [EasyStar.BOTTOM]);
+        easyStar.calculate();
 
-      easyStar.findPath(2, 0, 0, 0, function (path) {
-          expect(path).not.toBeNull();
-          expect(path.length).toEqual(5);
-          expect(path[2]).toEqual({ x: 1, y: 1})
-          done();
-      });
+        function onPathFound (path) {
+            expect(path).not.toBeNull();
+            expect(path.length).toEqual(5);
+            expect(path[0].x).toEqual(1);
+            expect(path[0].y).toEqual(2);
+            expect(path[2].x).toEqual(2);
+            expect(path[2].y).toEqual(3);
+            done();
+        }
+    });
 
-      easyStar.calculate();
-  })
+    it('It should be able to cancel a path.', function (done) {
+        var easyStar = new EasyStar.js();
+        var map = [[1, 1, 0, 1, 1],
+            [1, 1, 0, 1, 1],
+            [1, 1, 0, 1, 1],
+            [1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1]];
+
+        easyStar.setGrid(map);
+
+        easyStar.setAcceptableTiles([1]);
+
+        var id = easyStar.findPath(1, 2, 3, 2, onPathFound);
+
+        easyStar.cancelPath(id);
+
+        easyStar.calculate();
+
+        function onPathFound (path) {
+            fail('path wasn\'t cancelled');
+        }
+
+        setTimeout(done, 0);
+    });
+
+    it('Paths should have different IDs.', function () {
+        var easyStar = new EasyStar.js();
+        var map = [[1, 1, 0, 1, 1],
+            [1, 1, 0, 1, 1],
+            [1, 1, 0, 1, 1],
+            [1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1]];
+
+        easyStar.setGrid(map);
+
+        easyStar.setAcceptableTiles([1]);
+
+        var id1 = easyStar.findPath(1, 2, 3, 2, onPathFound);
+        var id2 = easyStar.findPath(3, 2, 1, 2, onPathFound);
+        expect(id1).toBeGreaterThan(0);
+        expect(id2).toBeGreaterThan(0);
+        expect(id1).not.toEqual(id2);
+
+        function onPathFound (path) {
+        }
+    });
+
+    it('It should be able to avoid a separate point successfully.', function (done) {
+        var easyStar = new EasyStar.js();
+        var map = [[1, 1, 0, 1, 1],
+            [1, 1, 0, 1, 1],
+            [1, 1, 0, 1, 1],
+            [1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1]];
+
+        easyStar.setGrid(map);
+
+        easyStar.avoidAdditionalPoint(2, 3);
+
+        easyStar.setAcceptableTiles([1]);
+
+        easyStar.findPath(1, 2, 3, 2, onPathFound);
+
+        easyStar.calculate();
+
+        function onPathFound (path) {
+            expect(path).not.toBeNull();
+            expect(path.length).toEqual(7);
+            expect(path[0].x).toEqual(1);
+            expect(path[0].y).toEqual(2);
+            expect(path[2].x).toEqual(1);
+            expect(path[2].y).toEqual(4);
+            done();
+        }
+    });
+
+    it('It should work with diagonals', function (done) {
+        var easyStar = new EasyStar.js();
+        easyStar.enableDiagonals();
+        var map = [[1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1]];
+
+        easyStar.setGrid(map);
+
+        easyStar.setAcceptableTiles([1]);
+
+        easyStar.findPath(0, 0, 4, 4, onPathFound);
+
+        easyStar.calculate();
+
+        function onPathFound (path) {
+            expect(path).not.toBeNull();
+            expect(path.length).toEqual(5);
+            expect(path[0].x).toEqual(0);
+            expect(path[0].y).toEqual(0);
+            expect(path[1].x).toEqual(1);
+            expect(path[1].y).toEqual(1);
+            expect(path[2].x).toEqual(2);
+            expect(path[2].y).toEqual(2);
+            expect(path[3].x).toEqual(3);
+            expect(path[3].y).toEqual(3);
+            expect(path[4].x).toEqual(4);
+            expect(path[4].y).toEqual(4);
+            done();
+        }
+    });
+
+    it('It should move in a straight line with diagonals', function (done) {
+        var easyStar = new EasyStar.js();
+        easyStar.enableDiagonals();
+        var map = [[1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            [1, 1, 0, 1, 1, 1, 1, 0, 1, 1],
+            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]];
+
+        easyStar.setGrid(map);
+
+        easyStar.enableDiagonals();
+
+        easyStar.setAcceptableTiles([1]);
+
+        easyStar.findPath(0, 0, 9, 0, onPathFound);
+
+        easyStar.calculate();
+
+        function onPathFound (path) {
+            expect(path).not.toBeNull();
+            for (var i = 0; i < path.length; i++) {
+                expect(path[i].y).toEqual(0);
+            }
+            done();
+        }
+    });
+
+    it('It should return empty path when start and end are the same tile.', function (done) {
+        var easyStar = new EasyStar.js();
+        var map = [[1, 1, 0, 1, 1],
+            [1, 1, 0, 1, 1],
+            [1, 1, 0, 1, 1],
+            [1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1]];
+
+        easyStar.setGrid(map);
+
+        easyStar.setAcceptableTiles([1]);
+
+        easyStar.findPath(1, 2, 1, 2, onPathFound);
+
+        easyStar.calculate();
+
+        function onPathFound (path) {
+            expect(path).not.toBeNull();
+            expect(path.length).toEqual(0);
+            done();
+        }
+    });
+
+    it('It should prefer straight paths when possible', function (done) {
+        var easyStar = new EasyStar.js();
+        easyStar.setAcceptableTiles([0]);
+        easyStar.enableDiagonals();
+        easyStar.setGrid([
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0]
+        ]);
+
+        easyStar.findPath(0, 1, 2, 1, function (path) {
+            expect(path).not.toBeNull();
+            expect(path[1].x).toEqual(1);
+            expect(path[1].y).toEqual(1);
+            done();
+        });
+
+        easyStar.calculate();
+    });
+
+    it('It should prefer diagonal paths when they are faster', function (done) {
+        var easyStar = new EasyStar.js();
+        var grid = [];
+        for (var i = 0; i < 20; i++) {
+            grid[i] = [];
+            for (var j = 0; j < 20; j++) {
+                grid[i][j] = 0;
+            }
+        }
+        easyStar.setGrid(grid);
+        easyStar.setAcceptableTiles([0]);
+        easyStar.enableDiagonals();
+
+        easyStar.findPath(4, 4, 2, 2, function (path) {
+            expect(path).not.toBeNull();
+            expect(path.length).toEqual(3);
+            expect(path[1].x).toEqual(3);
+            expect(path[1].y).toEqual(3);
+            done();
+        });
+
+        easyStar.calculate();
+    });
+
+    it('It should handle tiles with a directional condition', function (done) {
+        var easyStar = new EasyStar.js();
+        var grid = [
+            [0, 1, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+        ];
+        easyStar.setGrid(grid);
+        easyStar.enableDiagonals();
+        easyStar.setAcceptableTiles([0]);
+        easyStar.setDirectionalCondition(2, 1, [EasyStar.TOP]);
+        easyStar.setDirectionalCondition(1, 2, [EasyStar.TOP_RIGHT]);
+        easyStar.setDirectionalCondition(2, 2, [EasyStar.LEFT]);
+        easyStar.setDirectionalCondition(1, 1, [EasyStar.BOTTOM_RIGHT]);
+        easyStar.setDirectionalCondition(0, 1, [EasyStar.RIGHT]);
+        easyStar.setDirectionalCondition(0, 0, [EasyStar.BOTTOM]);
+
+        easyStar.findPath(2, 0, 0, 0, function (path) {
+            expect(path).not.toBeNull();
+            expect(path.length).toEqual(7);
+            expect(path[3]).toEqual({x: 2, y: 2});
+            done();
+        });
+
+        easyStar.calculate();
+    });
+
+    it('It should handle tiles with a directional condition and no corner cutting', function (done) {
+        var easyStar = new EasyStar.js();
+        easyStar.disableCornerCutting();
+        var grid = [
+            [0, 1, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+        ];
+        easyStar.setGrid(grid);
+        easyStar.enableDiagonals();
+        easyStar.setAcceptableTiles([0]);
+        easyStar.setDirectionalCondition(2, 1, [EasyStar.TOP]);
+        easyStar.setDirectionalCondition(1, 1, [EasyStar.RIGHT]);
+        easyStar.setDirectionalCondition(0, 1, [EasyStar.RIGHT]);
+        easyStar.setDirectionalCondition(0, 0, [EasyStar.BOTTOM]);
+
+        easyStar.findPath(2, 0, 0, 0, function (path) {
+            expect(path).not.toBeNull();
+            expect(path.length).toEqual(5);
+            expect(path[2]).toEqual({x: 1, y: 1});
+            done();
+        });
+
+        easyStar.calculate();
+    });
+
+    describe('Synchronous', function () {
+        it('It should invoke the findPath callback immediately when sync mode is enabled', function () {
+            var easyStar = new EasyStar.js();
+            var result = [];
+            var grid = [
+                [0, 1, 0],
+                [0, 0, 0],
+                [0, 0, 0],
+            ];
+
+            easyStar.enableSync();
+            easyStar.setGrid(grid);
+            easyStar.setAcceptableTiles([0]);
+
+            easyStar.findPath(0, 0, 1, 1, function (path) {
+                result.push.apply(result, path);
+            });
+
+            easyStar.calculate();
+
+            // Expect our result to be updated immediately
+            // after calculate is invoked
+            expect(result.length).toEqual(3);
+            expect(result[0]).toEqual({x: 0, y: 0});
+            expect(result[1]).toEqual({x: 0, y: 1});
+            expect(result[2]).toEqual({x: 1, y: 1});
+        });
+    });
+
+    describe('Asynchrounous', function () {
+        beforeEach(function () {
+            jasmine.clock().install();
+        });
+
+        afterEach(function () {
+            jasmine.clock().uninstall();
+        });
+
+        it('It should defer the findPath callback to the next stack when sync mode is not enabled', function () {
+            var easyStar = new EasyStar.js();
+            var result = [];
+            var grid = [
+                [0, 1, 0],
+                [0, 0, 0],
+                [0, 0, 0],
+            ];
+
+            easyStar.setGrid(grid);
+            easyStar.setAcceptableTiles([0]);
+
+            easyStar.findPath(0, 0, 1, 1, function (path) {
+                result.push.apply(result, path);
+
+                expect(path.length).toEqual(3);
+                expect(path[0]).toEqual({x: 0, y: 0});
+                expect(path[1]).toEqual({x: 0, y: 1});
+                expect(path[2]).toEqual({x: 1, y: 1});
+            });
+
+            easyStar.calculate();
+
+            // Expect our result to be deferred until
+            // it is ready
+            expect(result.length).toEqual(0);
+        });
+    });
 });


### PR DESCRIPTION
The proposal is an implementation similar to (https://github.com/prettymuchbryce/easystarjs/pull/54).

This change would not remove or modify from the existing public API or existing `enableSync()` method. It adds an additional method to the public API that allows users to find a path and calculate it's route truly synchronously with no callback.

Example usage...
```
var easyStar = new EasyStar.js();
var grid = [
    [0, 1, 0],
    [0, 0, 0],
    [0, 0, 0],
];
easyStar.setGrid(grid);
easyStar.setAcceptableTiles([0]);

const path = easyStar.findPathSync(0, 0, 1, 1); // your path array or null
```

I've done some semicolon and JSDoc housekeeping along the way, as well as added tests for the existing `enableSync()` behaviour.
